### PR TITLE
vpu_wrapper_hantro_VCencoder: add sys/time.h for gettimeofday

### DIFF
--- a/vpu_wrapper_hantro_VCencoder.c
+++ b/vpu_wrapper_hantro_VCencoder.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 #include <time.h>
 #include <math.h>
 #include <fcntl.h>


### PR DESCRIPTION
Fixes:
| ../git/vpu_wrapper_hantro_VCencoder.c:1965:5: error: implicit declaration of function 'gettimeofday' [-Wimplicit-function-declaration]
|  1965 |     gettimeofday (&pObj->tvBegin, NULL);
|       |     ^~~~~~~~~~~~